### PR TITLE
DEVOPS-409: npm supply chain protections

### DIFF
--- a/.github/actions/setup-frontend-environment/action.yml
+++ b/.github/actions/setup-frontend-environment/action.yml
@@ -18,6 +18,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@v2
+      with:
+        egress-policy: audit
+
     - name: Setup node
       uses: actions/setup-node@v4
       with:
@@ -43,6 +48,11 @@ runs:
     - name: Print Yarn cache size
       shell: bash
       run: du -d 0 -h ${{ steps.yarn-cache-dir-path.outputs.dir }}
+
+    - name: Audit dependencies
+      working-directory: "${{ inputs.directory }}"
+      shell: bash
+      run: yarn audit --groups dependencies
 
     - name: Install yarn dependencies
       working-directory: "${{ inputs.directory }}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,22 @@ updates:
       - "bot"
     commit-message:
       prefix: "ci:"
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      timezone: "Europe/London"
+      time: "09:00"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "bot"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -1,0 +1,28 @@
+name: "Lockfile audit"
+
+on:
+  pull_request:
+    paths:
+      - "web/yarn.lock"
+      - "web/package-lock.json"
+      - "yarn.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  check-non-registry-sources:
+    name: "Check for non-registry sources"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if yarn.lock resolves from non-registry sources
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD -- web/yarn.lock \
+            | grep '^+.*resolved' \
+            | grep -vE '"https://registry\.yarnpkg\.com|https://registry\.npmjs\.org' \
+            && echo "ERROR: Non-registry source detected in yarn.lock" && exit 1 \
+            || echo "OK: all resolved sources are from the npm registry"

--- a/.github/workflows/tests-yarn-e2e.yml
+++ b/.github/workflows/tests-yarn-e2e.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install e2e dependencies
         working-directory: ${{ env.FRONTEND_MONOREPO_DIR }}/libs/editor/tests/e2e
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Run LSO server
         id: run-lso-server

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=14

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=14
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ RUN yarn config set network-timeout 1200000 # HTTP timeout used when downloading
 COPY web/package.json .
 COPY web/yarn.lock .
 COPY web/tools tools
+RUN yarn audit --groups dependencies
 RUN --mount=type=cache,target=${YARN_CACHE_FOLDER},sharing=locked \
     --mount=type=cache,target=${NX_CACHE_DIRECTORY},sharing=locked \
-    yarn install --prefer-offline --no-progress --pure-lockfile --frozen-lockfile --ignore-engines --non-interactive --production=false
+    yarn install --prefer-offline --no-progress --pure-lockfile --frozen-lockfile --non-interactive --production=false
 
 COPY web .
 COPY pyproject.toml ../pyproject.toml

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "npm": ">=11.10.0"
+  },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.26.10",
     "@babel/plugin-transform-typescript": "^7.27.0",

--- a/web/.husky/post-checkout
+++ b/web/.husky/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx -y copy-files-from-to

--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Check staged yarn.lock for non-registry resolved sources
+if git diff --cached --name-only | grep -q "yarn\.lock"; then
+  git diff --cached -- yarn.lock \
+    | grep '^+.*resolved' \
+    | grep -vE '"https://registry\.yarnpkg\.com|https://registry\.npmjs\.org' \
+    && echo "ERROR: yarn.lock contains non-registry resolved source. Commit blocked." && exit 1 \
+    || true
+fi

--- a/web/.husky/pre-push
+++ b/web/.husky/pre-push
@@ -1,0 +1,2 @@
+#!/bin/sh
+yarn audit --groups dependencies

--- a/web/.yarnrc
+++ b/web/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,8 @@
     "storybook:serve": "nx storybook storybook",
     "storybook:build": "nx build-storybook storybook",
     "editor:build-npm": "NODE_ENV=production NX_TASK_TARGET_PROJECT=editor yarn nx build editor --prod && cp libs/editor/package.template.json dist/libs/editor/package.json",
-    "editor:publish": "cd dist/libs/editor && npm publish --access public"
+    "editor:publish": "cd dist/libs/editor && npm publish --access public",
+    "prepare": "husky .husky"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary

Addresses the supply chain attack vector documented in [TanStack/router#7383](https://github.com/TanStack/router/issues/7383) (Mini Shai-Hulud worm — compromised packages injected via `optionalDependencies` pointing to malicious GitHub forks).

This project uses **Yarn 1.x**, so `.npmrc` `min-release-age` and `.yarnrc.yml` `npmMinimalAgeGate` (Yarn Berry) don't apply. These changes provide equivalent protection across CI, Docker, and local dev.

## Changes

**CI**
- `lockfile-audit.yml` — new workflow that diffs `yarn.lock` on every PR; fails if any new `resolved` line points outside `registry.yarnpkg.com` or `registry.npmjs.org` (directly targets the #7383 attack vector)
- `setup-frontend-environment/action.yml` — adds `harden-runner` (egress audit on all runners) and `yarn audit --groups dependencies` before install across all 6 frontend workflows

**Docker**
- `Dockerfile` — adds `yarn audit` before `yarn install`; removes `--ignore-engines` so engine conflicts surface rather than being silently bypassed

**Local dev (Husky v8)**
- `web/.husky/pre-commit` — blocks commits if staged `yarn.lock` contains non-registry `resolved` sources
- `web/.husky/pre-push` — runs `yarn audit` before every push
- `web/.husky/post-checkout` — fixes previously broken `copy-files-from-to` hook (was using Husky v4 inline config with v8 installed)
- `web/.yarnrc` — locks all local `yarn add` / `yarn install` to `registry.npmjs.org` only
- `web/package.json` — adds `prepare: husky .husky` to auto-activate hooks on `yarn install`

**Dependabot**
- `.github/dependabot.yml` — adds `npm` ecosystem for `/web`; weekly grouped PRs for dev and production deps

**npm enforcement**
- `.npmrc` — `engine-strict=true`
- `package.json` (root) — `engines.npm >=11.10.0`

## Test plan

- [ ] Run `cd web && yarn install` — confirms hooks activate via `prepare`
- [ ] Stage a `yarn.lock` with a `github:` resolved line — pre-commit hook should block
- [ ] `git push` — pre-push hook should run `yarn audit` before pushing
- [ ] `git checkout` another branch — post-checkout hook should run `copy-files-from-to`
- [ ] Open a test PR touching `yarn.lock` with a non-registry source — `lockfile-audit` workflow should fail
- [ ] Confirm Docker build runs `yarn audit` step before install